### PR TITLE
Sync data-flywheel: labeling, aj fix, signal timestamps

### DIFF
--- a/ai-model-distillation-for-financial-data/config/config.yaml
+++ b/ai-model-distillation-for-financial-data/config/config.yaml
@@ -102,6 +102,18 @@ backtest_config:
   cost_bps: 5.0
   min_signals: 10
 
+# Signal generation: system prompt for trading direction classification
+signal_config:
+  system_prompt: >-
+    You are a financial trading signal generator.
+    Analyze the given financial news headline and respond with exactly one of: BUY, SELL, or HOLD.
+    Follow your recommendation with a brief one-sentence rationale.
+    Example: BUY — Earnings beat expectations, indicating strong growth momentum.
+  labeling:
+    enabled: true
+    return_threshold_bps: 50.0
+    horizon: "1D"
+
 # Training config:
 # Customization config with default values
 training_config:

--- a/ai-model-distillation-for-financial-data/deploy/deploy-eks.sh
+++ b/ai-model-distillation-for-financial-data/deploy/deploy-eks.sh
@@ -29,7 +29,7 @@ export AWS_REGION="${AWS_REGION:-us-west-2}"
 export AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID:-$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo "")}"
 export EKS_CLUSTER_NAME="${EKS_CLUSTER_NAME:-data-flywheel-dev}"
 export ECR_REPO_NAME="${ECR_REPO_NAME:-data-flywheel-server}"
-export IMAGE_TAG="${IMAGE_TAG:-0.5.1}"
+export IMAGE_TAG="${IMAGE_TAG:-0.5.6}"
 export ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 export ECR_IMAGE="${ECR_REGISTRY}/${ECR_REPO_NAME}:${IMAGE_TAG}"
 

--- a/ai-model-distillation-for-financial-data/deploy/helm/data-flywheel/templates/api-deployment.yaml
+++ b/ai-model-distillation-for-financial-data/deploy/helm/data-flywheel/templates/api-deployment.yaml
@@ -95,14 +95,15 @@ spec:
             httpGet:
               path: /health
               port: {{ .Values.foundationalFlywheelServer.deployments.api.service.port }}
-            initialDelaySeconds: 15
+            initialDelaySeconds: 90
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /health
               port: {{ .Values.foundationalFlywheelServer.deployments.api.service.port }}
-            initialDelaySeconds: 30
+            initialDelaySeconds: 120
             periodSeconds: 15
+            failureThreshold: 5
           command:
             {{- toYaml .Values.foundationalFlywheelServer.deployments.api.command | nindent 12 }}
           volumeMounts:

--- a/ai-model-distillation-for-financial-data/kdbx/backtest.py
+++ b/ai-model-distillation-for-financial-data/kdbx/backtest.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 _BACKTEST_Q = """\
 {[mid;cost]
-  sigs: select from signals where model_id = mid;
+  sigs: select from signals where model_id = mid, direction in `BUY`SELL;
   entry: aj[`sym`timestamp; sigs;
     select sym, timestamp, entry_price:close from market_ticks];
   exits: aj[`sym`timestamp;
@@ -65,7 +65,7 @@ _BACKTEST_Q = """\
 
 _BACKTEST_UNIVERSE_Q = """\
 {[mid;cost;syms]
-  sigs: select from signals where model_id = mid, sym in syms;
+  sigs: select from signals where model_id = mid, sym in syms, direction in `BUY`SELL;
   entry: aj[`sym`timestamp; sigs;
     select sym, timestamp, entry_price:close from market_ticks];
   exits: aj[`sym`timestamp;

--- a/ai-model-distillation-for-financial-data/kdbx/labeling.py
+++ b/ai-model-distillation-for-financial-data/kdbx/labeling.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 KX Systems, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Market-return-based training data labeling via KDB-X as-of joins.
+
+Computes next-day return labels (BUY/SELL/HOLD) by joining training record
+timestamps against ``market_ticks`` to get entry and exit prices.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pandas as pd
+import pykx as kx
+
+from kdbx.connection import pykx_connection
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# q lambda — batch return lookup via aj
+# ---------------------------------------------------------------------------
+
+_RETURN_LABELS_Q = """\
+{[syms;timestamps]
+  lookup: ([] sym: syms; timestamp: timestamps);
+  entry: aj[`sym`timestamp; lookup;
+    select sym, timestamp, entry_price:close from market_ticks];
+  exit_lookup: update timestamp: timestamp + 1D from lookup;
+  exits: aj[`sym`timestamp; exit_lookup;
+    select sym, timestamp, exit_price:close from market_ticks];
+  update exit_price: exits`exit_price from entry
+ }"""
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_return_labels_batch(
+    syms: list[str],
+    timestamps: list[str | Any],
+    threshold_bps: float,
+) -> list[dict[str, Any]]:
+    """Compute next-day return labels for a batch of (sym, timestamp) pairs.
+
+    Parameters
+    ----------
+    syms : list[str]
+        Ticker symbols.
+    timestamps : list
+        ISO-8601 timestamp strings or datetime-like objects.
+    threshold_bps : float
+        Threshold in basis points.  return > +threshold → BUY,
+        < -threshold → SELL, else HOLD.
+
+    Returns
+    -------
+    list[dict]
+        One dict per input with keys ``entry_price``, ``exit_price``,
+        ``return_pct``, ``direction``.  ``direction`` is None when
+        market data is missing.
+    """
+    if not syms:
+        return []
+
+    ts_dt = [pd.Timestamp(t).to_pydatetime() for t in timestamps]
+    threshold_pct = threshold_bps / 100.0  # bps → percent
+
+    with pykx_connection() as q:
+        result = q(
+            _RETURN_LABELS_Q,
+            kx.SymbolVector(syms),
+            kx.TimestampVector(ts_dt),
+        )
+
+    try:
+        df = result.pd() if hasattr(result, "pd") else pd.DataFrame()
+    except Exception:
+        df = pd.DataFrame()
+
+    labels: list[dict[str, Any]] = []
+    for i in range(len(syms)):
+        if i < len(df):
+            row = df.iloc[i]
+            entry = row.get("entry_price")
+            exit_ = row.get("exit_price")
+        else:
+            entry = None
+            exit_ = None
+
+        if entry is None or exit_ is None or pd.isna(entry) or pd.isna(exit_):
+            labels.append({
+                "entry_price": None,
+                "exit_price": None,
+                "return_pct": None,
+                "direction": None,
+            })
+            continue
+
+        entry_f = float(entry)
+        exit_f = float(exit_)
+        ret_pct = ((exit_f - entry_f) / entry_f) * 100.0
+
+        if ret_pct > threshold_pct:
+            direction = "BUY"
+        elif ret_pct < -threshold_pct:
+            direction = "SELL"
+        else:
+            direction = "HOLD"
+
+        labels.append({
+            "entry_price": entry_f,
+            "exit_price": exit_f,
+            "return_pct": round(ret_pct, 4),
+            "direction": direction,
+        })
+
+    return labels
+
+
+def generate_template_rationale(
+    direction: str,
+    sym: str,
+    return_pct: float,
+    entry_price: float,
+    exit_price: float,
+) -> str:
+    """Generate a template rationale string for a labeled record.
+
+    Returns
+    -------
+    str
+        e.g. ``"BUY — AAPL next-day return +1.50% ($185.50 → $188.28)"``
+    """
+    sign = "+" if return_pct >= 0 else ""
+    return (
+        f"{direction} \u2014 {sym} next-day return "
+        f"{sign}{return_pct:.2f}% (${entry_price:.2f} \u2192 ${exit_price:.2f})"
+    )

--- a/ai-model-distillation-for-financial-data/kdbx/market_tables.py
+++ b/ai-model-distillation-for-financial-data/kdbx/market_tables.py
@@ -194,8 +194,8 @@ def load_parquet_data(parquet_path: str) -> dict[str, int]:
             kx.toq(ticks["trade_count"].values),
             kx.SymbolVector(ticks["source"].tolist()),
         )
-        # Apply sorted attribute on sym for fast aj lookups
-        q("update `s#sym from `market_ticks")
+        # Sort in-place by sym,timestamp for correct aj lookups
+        q("`sym`timestamp xasc `market_ticks")
         tick_count = int(q("count market_ticks").py())
         logger.info("Inserted %d rows into market_ticks", tick_count)
 
@@ -211,7 +211,7 @@ def load_parquet_data(parquet_path: str) -> dict[str, int]:
             kx.toq(book["mid"].values),
             kx.toq(book["spread"].values),
         )
-        q("update `s#sym from `order_book")
+        q("`sym`timestamp xasc `order_book")
         book_count = int(q("count order_book").py())
         logger.info("Inserted %d rows into order_book", book_count)
 

--- a/ai-model-distillation-for-financial-data/scripts/load_alpaca_data.py
+++ b/ai-model-distillation-for-financial-data/scripts/load_alpaca_data.py
@@ -1,0 +1,459 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 KX Systems, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fetch real market data from Alpaca and load into KDB-X.
+
+POC script for running the data flywheel on real financial data.
+
+Usage
+-----
+# 1. Save Parquet only (no KDB-X needed):
+ALPACA_API_KEY=xxx ALPACA_SECRET_KEY=yyy \\
+    python scripts/load_alpaca_data.py --symbol AAPL --parquet-only
+
+# 2. Save Parquet + load into KDB-X:
+ALPACA_API_KEY=xxx ALPACA_SECRET_KEY=yyy KDBX_ENDPOINT=localhost:8082 \\
+    python scripts/load_alpaca_data.py --symbol AAPL
+
+# 3. Include news headlines (for flywheel_logs):
+ALPACA_API_KEY=xxx ALPACA_SECRET_KEY=yyy KDBX_ENDPOINT=localhost:8082 \\
+    python scripts/load_alpaca_data.py --symbol AAPL --with-news
+
+Environment
+-----------
+ALPACA_API_KEY     Alpaca API key ID (required)
+ALPACA_SECRET_KEY  Alpaca API secret key (required)
+KDBX_ENDPOINT      host:port of KDB-X (required unless --parquet-only)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+ALPACA_DATA_URL = "https://data.alpaca.markets"
+
+
+# ---------------------------------------------------------------------------
+# Alpaca API helpers
+# ---------------------------------------------------------------------------
+
+def _headers() -> dict[str, str]:
+    key = os.environ.get("ALPACA_API_KEY", "")
+    secret = os.environ.get("ALPACA_SECRET_KEY", "")
+    if not key or not secret:
+        logger.error("Set ALPACA_API_KEY and ALPACA_SECRET_KEY environment variables")
+        sys.exit(1)
+    return {"APCA-API-KEY-ID": key, "APCA-API-SECRET-KEY": secret}
+
+
+def fetch_bars(
+    symbol: str,
+    start: str,
+    end: str,
+    timeframe: str = "1Day",
+) -> pd.DataFrame:
+    """Fetch historical bars from Alpaca.
+
+    Parameters
+    ----------
+    symbol : str
+        Ticker symbol (e.g. ``"AAPL"``).
+    start, end : str
+        ISO-8601 date strings (``"2024-03-01"``).
+    timeframe : str
+        Alpaca timeframe: ``"1Min"``, ``"1Hour"``, ``"1Day"``, etc.
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns matching ``market_ticks`` schema.
+    """
+    url = f"{ALPACA_DATA_URL}/v2/stocks/{symbol}/bars"
+    all_bars: list[dict] = []
+    page_token = None
+
+    while True:
+        params: dict = {
+            "start": start,
+            "end": end,
+            "timeframe": timeframe,
+            "limit": 10000,
+            "feed": "iex",
+        }
+        if page_token:
+            params["page_token"] = page_token
+
+        resp = requests.get(url, headers=_headers(), params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+
+        bars = data.get("bars") or []
+        if not bars:
+            break
+        all_bars.extend(bars)
+        logger.info("Fetched %d bars (total: %d)", len(bars), len(all_bars))
+
+        page_token = data.get("next_page_token")
+        if not page_token:
+            break
+
+    if not all_bars:
+        logger.warning("No bars returned for %s", symbol)
+        return pd.DataFrame()
+
+    df = pd.DataFrame(all_bars)
+    df = df.rename(columns={
+        "t": "timestamp",
+        "o": "open",
+        "h": "high",
+        "l": "low",
+        "c": "close",
+        "v": "volume",
+        "vw": "vwap",
+        "n": "trade_count",
+    })
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+    df["sym"] = symbol
+    df["source"] = "alpaca"
+
+    cols = ["sym", "timestamp", "open", "high", "low", "close",
+            "volume", "vwap", "trade_count", "source"]
+    return df[cols].sort_values("timestamp").reset_index(drop=True)
+
+
+def derive_order_book(bars_df: pd.DataFrame) -> pd.DataFrame:
+    """Derive order_book from bar data with realistic spread.
+
+    AAPL typically has a 1-2 cent spread. We use 0.01% of price
+    (floored at $0.01) to approximate NBBO.
+    """
+    book = bars_df[["sym", "timestamp", "close"]].copy()
+    half_spread = (book["close"] * 0.0001).clip(lower=0.005)
+    book["bid_price"] = (book["close"] - half_spread).round(4)
+    book["ask_price"] = (book["close"] + half_spread).round(4)
+    book["bid_size"] = 100
+    book["ask_size"] = 100
+    book["mid"] = book["close"].round(4)
+    book["spread"] = (half_spread * 2).round(4)
+    return book.drop(columns=["close"])
+
+
+def fetch_news(
+    symbol: str,
+    start: str,
+    end: str,
+    limit: int = 200,
+) -> pd.DataFrame:
+    """Fetch news headlines from Alpaca News API.
+
+    Returns a DataFrame with columns ready for ``flywheel_logs`` insertion.
+    """
+    url = f"{ALPACA_DATA_URL}/v1beta1/news"
+    all_news: list[dict] = []
+    page_token = None
+
+    while len(all_news) < limit:
+        params: dict = {
+            "symbols": symbol,
+            "start": start,
+            "end": end,
+            "limit": min(50, limit - len(all_news)),
+            "sort": "desc",
+        }
+        if page_token:
+            params["page_token"] = page_token
+
+        resp = requests.get(url, headers=_headers(), params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+
+        news = data.get("news") or []
+        if not news:
+            break
+        all_news.extend(news)
+        logger.info("Fetched %d news articles (total: %d)", len(news), len(all_news))
+
+        page_token = data.get("next_page_token")
+        if not page_token:
+            break
+
+    if not all_news:
+        logger.warning("No news returned for %s", symbol)
+        return pd.DataFrame()
+
+    records = []
+    for item in all_news:
+        headline = item.get("headline", "")
+        # Format as a classification request matching the flywheel prompt format
+        request_obj = {
+            "model": "teacher",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        f"Classify the following financial news headline for {symbol}: "
+                        f'"{headline}"'
+                    ),
+                }
+            ],
+        }
+        response_obj = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "",  # empty — teacher will label these
+                    }
+                }
+            ],
+        }
+        records.append({
+            "doc_id": str(uuid.uuid4()),
+            "workload_id": f"alpaca-news-{symbol.lower()}",
+            "client_id": "alpaca-poc",
+            "timestamp": item.get("created_at", ""),
+            "request": json.dumps(request_obj),
+            "response": json.dumps(response_obj),
+        })
+
+    df = pd.DataFrame(records)
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+    return df.sort_values("timestamp").reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Parquet output
+# ---------------------------------------------------------------------------
+
+def save_parquet(bars_df: pd.DataFrame, book_df: pd.DataFrame, out_dir: Path) -> Path:
+    """Save combined market data as Parquet compatible with load_parquet_data().
+
+    The output Parquet has all columns from both market_ticks and order_book
+    schemas, merged on (sym, timestamp).
+    """
+    combined = bars_df.merge(book_df, on=["sym", "timestamp"], how="left")
+    out_path = out_dir / "market_data.parquet"
+    combined.to_parquet(out_path, index=False)
+    logger.info("Saved %d rows to %s", len(combined), out_path)
+    return out_path
+
+
+def save_news_parquet(news_df: pd.DataFrame, out_dir: Path) -> Path:
+    """Save news headlines as Parquet."""
+    out_path = out_dir / "news_headlines.parquet"
+    news_df.to_parquet(out_path, index=False)
+    logger.info("Saved %d news articles to %s", len(news_df), out_path)
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# KDB-X loading
+# ---------------------------------------------------------------------------
+
+def _ts_to_q(ts: pd.Timestamp) -> str:
+    """Convert pandas Timestamp to q timestamp literal."""
+    if ts.tzinfo is not None:
+        ts = ts.tz_convert("UTC").tz_localize(None)
+    return ts.isoformat().replace("-", ".").replace("T", "D")
+
+
+def load_into_kdbx(parquet_path: Path) -> dict[str, int]:
+    """Load Parquet into KDB-X using IPC-safe PyKX (no license required).
+
+    Uses q string expressions to avoid the 8-parameter IPC limit
+    and the categorical/license issue with ``kx.toq()``.
+    """
+    from kdbx.connection import pykx_connection
+    from kdbx.market_tables import create_market_tables
+
+    create_market_tables(drop_existing=False)
+
+    df = pd.read_parquet(parquet_path)
+    logger.info("Read %d rows from %s", len(df), parquet_path)
+
+    # --- market_ticks ---
+    ticks = df[["sym", "timestamp", "open", "high", "low", "close",
+                "volume", "vwap", "trade_count", "source"]].copy()
+    ticks = ticks.sort_values(["sym", "timestamp"]).reset_index(drop=True)
+
+    # --- order_book ---
+    book = df[["sym", "timestamp", "bid_price", "bid_size",
+               "ask_price", "ask_size", "mid", "spread"]].copy()
+    book = book.sort_values(["sym", "timestamp"]).reset_index(drop=True)
+
+    with pykx_connection() as q:
+        # Insert market_ticks row-by-row via q expressions (no param limit)
+        for _, r in ticks.iterrows():
+            ts_q = _ts_to_q(r["timestamp"])
+            q(
+                f'`market_ticks insert `sym`timestamp`open`high`low`close`volume`vwap`trade_count`source!'
+                f'(`$"{r["sym"]}";{ts_q};{r["open"]};{r["high"]};{r["low"]};'
+                f'{r["close"]};{int(r["volume"])};{r["vwap"]};{int(r["trade_count"])};`$"{r["source"]}")'
+            )
+        q("`sym`timestamp xasc `market_ticks")
+        tick_count = int(q("count market_ticks").py())
+        logger.info("Inserted %d rows into market_ticks", tick_count)
+
+        # Insert order_book
+        for _, r in book.iterrows():
+            ts_q = _ts_to_q(r["timestamp"])
+            q(
+                f'`order_book insert `sym`timestamp`bid_price`bid_size`ask_price`ask_size`mid`spread!'
+                f'(`$"{r["sym"]}";{ts_q};{r["bid_price"]};{int(r["bid_size"])};'
+                f'{r["ask_price"]};{int(r["ask_size"])};{r["mid"]};{r["spread"]})'
+            )
+        q("`sym`timestamp xasc `order_book")
+        book_count = int(q("count order_book").py())
+        logger.info("Inserted %d rows into order_book", book_count)
+
+    return {"market_ticks": tick_count, "order_book": book_count}
+
+
+def load_news_into_kdbx(news_df: pd.DataFrame) -> int:
+    """Insert news records into flywheel_logs table."""
+    import pykx as kx
+
+    from kdbx.connection import pykx_connection
+    from kdbx.schema import create_all_tables
+
+    # Ensure tables exist
+    create_all_tables(drop_existing=False)
+
+    count = 0
+    with pykx_connection() as q:
+        for _, row in news_df.iterrows():
+            q(
+                "{[d;w;c;t;rq;rs] `flywheel_logs insert `doc_id`workload_id`client_id`timestamp`request`response!(d;w;c;t;rq;rs)}",
+                kx.SymbolAtom(row["doc_id"]),
+                kx.SymbolAtom(row["workload_id"]),
+                kx.SymbolAtom(row["client_id"]),
+                kx.TimestampAtom(row["timestamp"].to_pydatetime()),
+                str(row["request"]),
+                str(row["response"]),
+            )
+            count += 1
+
+        logger.info("Inserted %d records into flywheel_logs", count)
+    return count
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch real market data from Alpaca for POC",
+    )
+    parser.add_argument("--symbol", default="AAPL", help="Ticker symbol (default: AAPL)")
+    parser.add_argument(
+        "--days", type=int, default=365,
+        help="Number of calendar days of history (default: 365)",
+    )
+    parser.add_argument(
+        "--timeframe", default="1Day",
+        help="Bar timeframe: 1Min, 1Hour, 1Day (default: 1Day)",
+    )
+    parser.add_argument(
+        "--parquet-only", action="store_true",
+        help="Save Parquet files only, skip KDB-X loading",
+    )
+    parser.add_argument(
+        "--with-news", action="store_true",
+        help="Also fetch news headlines and load into flywheel_logs",
+    )
+    parser.add_argument(
+        "--news-limit", type=int, default=200,
+        help="Max news articles to fetch (default: 200)",
+    )
+    parser.add_argument(
+        "--out-dir", default="data/alpaca",
+        help="Output directory for Parquet files (default: data/alpaca)",
+    )
+    args = parser.parse_args()
+
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=args.days)
+    start_str = start.strftime("%Y-%m-%d")
+    end_str = end.strftime("%Y-%m-%d")
+
+    logger.info(
+        "Fetching %s data for %s from %s to %s",
+        args.timeframe, args.symbol, start_str, end_str,
+    )
+
+    # -- Fetch bars --
+    bars_df = fetch_bars(args.symbol, start_str, end_str, args.timeframe)
+    if bars_df.empty:
+        logger.error("No bar data returned. Check your Alpaca credentials and symbol.")
+        sys.exit(1)
+    logger.info("Got %d bars for %s", len(bars_df), args.symbol)
+
+    # -- Derive order book --
+    book_df = derive_order_book(bars_df)
+
+    # -- Save Parquet --
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    parquet_path = save_parquet(bars_df, book_df, out_dir)
+
+    # -- Fetch news --
+    news_df = pd.DataFrame()
+    if args.with_news:
+        news_df = fetch_news(args.symbol, start_str, end_str, args.news_limit)
+        if not news_df.empty:
+            save_news_parquet(news_df, out_dir)
+
+    # -- Load into KDB-X --
+    if not args.parquet_only:
+        logger.info("Loading market data into KDB-X...")
+        counts = load_into_kdbx(parquet_path)
+        logger.info("KDB-X market data: %s", counts)
+
+        if args.with_news and not news_df.empty:
+            logger.info("Loading %d news articles into flywheel_logs...", len(news_df))
+            n = load_news_into_kdbx(news_df)
+            logger.info("KDB-X flywheel_logs: %d records", n)
+
+    # -- Summary --
+    print(f"\n{'='*60}")
+    print(f"  Alpaca POC Data Load — {args.symbol}")
+    print(f"{'='*60}")
+    print(f"  Period:      {start_str} to {end_str}")
+    print(f"  Timeframe:   {args.timeframe}")
+    print(f"  Bars:        {len(bars_df):,}")
+    print(f"  Order book:  {len(book_df):,} (derived)")
+    if args.with_news:
+        print(f"  News:        {len(news_df):,} headlines")
+    print(f"  Parquet:     {parquet_path}")
+    if not args.parquet_only:
+        print(f"  KDB-X:       loaded")
+    print(f"{'='*60}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-model-distillation-for-financial-data/src/config.py
+++ b/ai-model-distillation-for-financial-data/src/config.py
@@ -100,6 +100,26 @@ class BacktestConfig(BaseModel):
     min_signals: int = 10
 
 
+class LabelingConfig(BaseModel):
+    """Config for market-return-based training data labeling."""
+
+    enabled: bool = True
+    return_threshold_bps: float = 50.0  # +/- 0.5% → BUY/SELL, else HOLD
+    horizon: str = "1D"  # next-day return lookforward
+
+
+class SignalConfig(BaseModel):
+    """Config for trading signal generation."""
+
+    system_prompt: str = (
+        "You are a financial trading signal generator. "
+        "Analyze the given financial news headline and respond with exactly one of: BUY, SELL, or HOLD. "
+        "Follow your recommendation with a brief one-sentence rationale. "
+        "Example: BUY — Earnings beat expectations, indicating strong growth momentum."
+    )
+    labeling: LabelingConfig = Field(default_factory=LabelingConfig)
+
+
 class TrainingConfig(BaseModel):
     training_type: str = Field(default="sft", description="Training type")
     finetuning_type: str = Field(default="lora", description="Finetuning type")
@@ -370,6 +390,7 @@ class Settings(BaseSettings):
     llm_judge_config: LLMJudgeConfig | None = None  # Optional, only needed for tool-calling-judge evaluation
     enrichment_config: EnrichmentConfig = Field(default_factory=EnrichmentConfig)
     backtest_config: BacktestConfig = Field(default_factory=BacktestConfig)
+    signal_config: SignalConfig = Field(default_factory=SignalConfig)
 
     @model_validator(mode="after")
     def validate_nims_not_empty(self) -> "Settings":
@@ -421,6 +442,11 @@ class Settings(BaseSettings):
                 if "backtest_config" in config_data
                 else BacktestConfig()
             )
+            signal_raw = config_data.get("signal_config", {})
+            labeling_raw = signal_raw.pop("labeling", None)
+            signal_config = SignalConfig(**signal_raw) if signal_raw else SignalConfig()
+            if labeling_raw:
+                signal_config.labeling = LabelingConfig(**labeling_raw)
 
             # Deduplicate NIMs by model_name
             # we should have only unique NIMs in the config
@@ -449,6 +475,7 @@ class Settings(BaseSettings):
                 llm_judge_config=llm_judge_config,
                 enrichment_config=enrichment_config,
                 backtest_config=backtest_config,
+                signal_config=signal_config,
             )
 
 

--- a/ai-model-distillation-for-financial-data/src/tasks/tasks.py
+++ b/ai-model-distillation-for-financial-data/src/tasks/tasks.py
@@ -265,6 +265,44 @@ def create_datasets(previous_result: TaskResult) -> TaskResult:
                         rec.pop("_enrich_sym", None)
                         rec.pop("_enrich_ts", None)
 
+        # --- Market-return labeling ---
+        if settings.signal_config.labeling.enabled:
+            from kdbx.labeling import compute_return_labels_batch, generate_template_rationale
+            from kdbx.enrichment import extract_sym_from_record
+
+            labelable = []
+            for rec in records:
+                if not isinstance(rec, dict):
+                    continue
+                sym = extract_sym_from_record(rec, settings.enrichment_config)
+                ts = rec.get(settings.enrichment_config.timestamp_field)
+                content = (rec.get("response", {}).get("choices", [{}])[0]
+                           .get("message", {}).get("content", ""))
+                if sym and ts and not content:
+                    labelable.append((rec, sym, ts))
+
+            if labelable:
+                try:
+                    labels = compute_return_labels_batch(
+                        [s for _, s, _ in labelable],
+                        [t for _, _, t in labelable],
+                        settings.signal_config.labeling.return_threshold_bps,
+                    )
+                    labeled_count = 0
+                    for (rec, sym, _), label in zip(labelable, labels):
+                        if label["direction"] is None:
+                            continue
+                        rationale = generate_template_rationale(
+                            label["direction"], sym,
+                            label["return_pct"], label["entry_price"], label["exit_price"],
+                        )
+                        rec["response"]["choices"][0]["message"]["content"] = rationale
+                        labeled_count += 1
+                    logger.info("Labeled %d/%d records with market-return directions",
+                                labeled_count, len(labelable))
+                except Exception as e:
+                    logger.warning("Labeling failed (non-fatal): %s", e)
+
         # The workload type is identified based on the records.
         # This is used to determine the type of evaluation to be run.
         # Config can override auto-detection with explicit workload_type setting
@@ -961,19 +999,30 @@ def run_customization_eval(previous_result: TaskResult) -> TaskResult:
         return previous_result
 
 
+_BUY_KEYWORDS = [
+    "BUY", "BULLISH", "LONG", "UPGRADE", "BEAT",
+    "OUTPERFORM", "OVERWEIGHT", "POSITIVE", "ACCUMULATE",
+]
+_SELL_KEYWORDS = [
+    "SELL", "BEARISH", "SHORT", "DOWNGRADE", "MISS",
+    "UNDERPERFORM", "UNDERWEIGHT", "NEGATIVE", "REDUCE",
+    "CRASH", "DECLINE",
+]
+
+
 def _parse_direction(response_text: str) -> str:
     """Extract trading direction from model response text.
 
-    Performs case-insensitive keyword search for BUY/SELL/HOLD.
-    Returns ``"HOLD"`` if none found.
+    Performs case-insensitive keyword search against financial sentiment
+    terms.  Returns ``"HOLD"`` if no actionable keyword is found.
     """
     upper = response_text.upper()
-    if "BUY" in upper:
-        return "BUY"
-    if "SELL" in upper:
-        return "SELL"
-    if "HOLD" in upper:
-        return "HOLD"
+    for kw in _BUY_KEYWORDS:
+        if kw in upper:
+            return "BUY"
+    for kw in _SELL_KEYWORDS:
+        if kw in upper:
+            return "SELL"
     return "HOLD"
 
 
@@ -1025,6 +1074,10 @@ def generate_signals(previous_result: TaskResult, model_type: str = "base") -> T
             if not messages:
                 continue
 
+            # Inject system prompt for trading direction classification
+            if not messages or messages[0].get("role") != "system":
+                messages = [{"role": "system", "content": settings.signal_config.system_prompt}] + messages
+
             try:
                 resp = requests.post(
                     nim_url,
@@ -1043,9 +1096,13 @@ def generate_signals(previous_result: TaskResult, model_type: str = "base") -> T
             if not sym:
                 continue
 
+            # Use original event timestamp for backtesting; fall back to now
+            event_ts = rec.get(settings.enrichment_config.timestamp_field)
+            sig_ts = datetime.fromisoformat(event_ts) if event_ts else datetime.utcnow()
+
             signals_batch.append({
                 "signal_id": str(uuid.uuid4()),
-                "timestamp": datetime.utcnow(),
+                "timestamp": sig_ts,
                 "sym": sym,
                 "direction": direction,
                 "confidence": 0.0,

--- a/ai-model-distillation-for-financial-data/tests/unit/kdbx/test_backtest.py
+++ b/ai-model-distillation-for-financial-data/tests/unit/kdbx/test_backtest.py
@@ -76,6 +76,16 @@ class TestBacktestQStrings:
 
         assert "$[" in _BACKTEST_Q, "Backtest q should use $[cond;...] ternary"
 
+    def test_q_filters_hold_signals(self):
+        from kdbx.backtest import _BACKTEST_Q, _BACKTEST_UNIVERSE_Q
+
+        assert "direction in `BUY`SELL" in _BACKTEST_Q, (
+            "Base q must filter out HOLD signals"
+        )
+        assert "direction in `BUY`SELL" in _BACKTEST_UNIVERSE_Q, (
+            "Universe q must filter out HOLD signals"
+        )
+
     def test_q_does_not_contain_user_values(self):
         """The q string should not embed any model_id or cost values."""
         from kdbx.backtest import _BACKTEST_Q

--- a/ai-model-distillation-for-financial-data/tests/unit/kdbx/test_labeling.py
+++ b/ai-model-distillation-for-financial-data/tests/unit/kdbx/test_labeling.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 KX Systems, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for kdbx.labeling module.
+
+Covers:
+  - BUY / SELL / HOLD direction from return vs threshold
+  - Template rationale format
+  - Missing market data → None direction
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixture — same pattern as test_enrichment.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_q():
+    """Patch pykx_connection and kx where labeling.py uses them."""
+    mock_conn = MagicMock(name="SyncQConnection")
+
+    @contextmanager
+    def _fake_ctx():
+        yield mock_conn
+
+    with (
+        patch("kdbx.labeling.pykx_connection", _fake_ctx),
+        patch("kdbx.labeling.kx") as mock_kx,
+    ):
+        mock_kx.SymbolVector.side_effect = lambda v: ("SymbolVector", list(v))
+        mock_kx.TimestampVector.side_effect = lambda v: ("TimestampVector", list(v))
+        yield mock_conn, mock_kx
+
+
+def _make_result(rows: list[dict]) -> MagicMock:
+    result = MagicMock()
+    result.pd.return_value = pd.DataFrame(rows)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# compute_return_labels_batch tests
+# ---------------------------------------------------------------------------
+
+
+class TestReturnLabels:
+    def test_buy_when_return_exceeds_threshold(self, mock_q):
+        """Return +1.5% with threshold 50bps → BUY."""
+        mock_conn, _ = mock_q
+        mock_conn.return_value = _make_result([
+            {"entry_price": 100.0, "exit_price": 101.5},
+        ])
+
+        from kdbx.labeling import compute_return_labels_batch
+
+        labels = compute_return_labels_batch(["AAPL"], ["2025-06-15T10:00:00"], 50.0)
+
+        assert len(labels) == 1
+        assert labels[0]["direction"] == "BUY"
+        assert labels[0]["return_pct"] == pytest.approx(1.5, abs=0.01)
+
+    def test_sell_when_return_below_negative_threshold(self, mock_q):
+        """Return -1.0% with threshold 50bps → SELL."""
+        mock_conn, _ = mock_q
+        mock_conn.return_value = _make_result([
+            {"entry_price": 100.0, "exit_price": 99.0},
+        ])
+
+        from kdbx.labeling import compute_return_labels_batch
+
+        labels = compute_return_labels_batch(["AAPL"], ["2025-06-15T10:00:00"], 50.0)
+
+        assert labels[0]["direction"] == "SELL"
+        assert labels[0]["return_pct"] == pytest.approx(-1.0, abs=0.01)
+
+    def test_hold_when_return_within_threshold(self, mock_q):
+        """Return +0.3% with threshold 50bps → HOLD."""
+        mock_conn, _ = mock_q
+        mock_conn.return_value = _make_result([
+            {"entry_price": 100.0, "exit_price": 100.3},
+        ])
+
+        from kdbx.labeling import compute_return_labels_batch
+
+        labels = compute_return_labels_batch(["AAPL"], ["2025-06-15T10:00:00"], 50.0)
+
+        assert labels[0]["direction"] == "HOLD"
+
+    def test_no_exit_price_returns_none(self, mock_q):
+        """Missing exit price → direction is None."""
+        mock_conn, _ = mock_q
+        mock_conn.return_value = _make_result([
+            {"entry_price": 100.0, "exit_price": None},
+        ])
+
+        from kdbx.labeling import compute_return_labels_batch
+
+        labels = compute_return_labels_batch(["AAPL"], ["2025-06-15T10:00:00"], 50.0)
+
+        assert labels[0]["direction"] is None
+        assert labels[0]["entry_price"] is None
+
+    def test_no_entry_price_returns_none(self, mock_q):
+        """Missing entry price → direction is None."""
+        mock_conn, _ = mock_q
+        mock_conn.return_value = _make_result([
+            {"entry_price": None, "exit_price": 101.0},
+        ])
+
+        from kdbx.labeling import compute_return_labels_batch
+
+        labels = compute_return_labels_batch(["AAPL"], ["2025-06-15T10:00:00"], 50.0)
+
+        assert labels[0]["direction"] is None
+
+    def test_empty_input_returns_empty(self, mock_q):
+        mock_conn, _ = mock_q
+
+        from kdbx.labeling import compute_return_labels_batch
+
+        labels = compute_return_labels_batch([], [], 50.0)
+
+        assert labels == []
+        mock_conn.assert_not_called()
+
+    def test_batch_multiple_records(self, mock_q):
+        """Three records: BUY, SELL, HOLD."""
+        mock_conn, _ = mock_q
+        mock_conn.return_value = _make_result([
+            {"entry_price": 100.0, "exit_price": 102.0},  # +2% → BUY
+            {"entry_price": 100.0, "exit_price": 98.0},   # -2% → SELL
+            {"entry_price": 100.0, "exit_price": 100.1},  # +0.1% → HOLD
+        ])
+
+        from kdbx.labeling import compute_return_labels_batch
+
+        labels = compute_return_labels_batch(
+            ["AAPL", "MSFT", "GOOG"],
+            ["2025-06-15T10:00:00"] * 3,
+            50.0,
+        )
+
+        assert len(labels) == 3
+        assert labels[0]["direction"] == "BUY"
+        assert labels[1]["direction"] == "SELL"
+        assert labels[2]["direction"] == "HOLD"
+
+
+# ---------------------------------------------------------------------------
+# generate_template_rationale tests
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateRationale:
+    def test_format_buy(self):
+        from kdbx.labeling import generate_template_rationale
+
+        result = generate_template_rationale("BUY", "AAPL", 1.50, 185.50, 188.28)
+
+        assert result.startswith("BUY")
+        assert "AAPL" in result
+        assert "+1.50%" in result
+        assert "$185.50" in result
+        assert "$188.28" in result
+
+    def test_format_sell(self):
+        from kdbx.labeling import generate_template_rationale
+
+        result = generate_template_rationale("SELL", "MSFT", -2.30, 400.00, 390.80)
+
+        assert result.startswith("SELL")
+        assert "MSFT" in result
+        assert "-2.30%" in result
+
+    def test_format_hold(self):
+        from kdbx.labeling import generate_template_rationale
+
+        result = generate_template_rationale("HOLD", "GOOG", 0.10, 150.00, 150.15)
+
+        assert result.startswith("HOLD")
+        assert "+0.10%" in result

--- a/ai-model-distillation-for-financial-data/tests/unit/kdbx/test_market_tables.py
+++ b/ai-model-distillation-for-financial-data/tests/unit/kdbx/test_market_tables.py
@@ -255,10 +255,10 @@ class TestLoadParquetData:
             load_parquet_data("/fake/path.parquet")
 
         q_calls = [c.args[0] for c in mock_q.call_args_list]
-        sorted_calls = [c for c in q_calls if "`s#sym" in c]
+        xasc_calls = [c for c in q_calls if "xasc" in c]
         # One for market_ticks, one for order_book
-        assert len(sorted_calls) == 2, \
-            "Should apply `s#sym to both market_ticks and order_book"
+        assert len(xasc_calls) == 2, \
+            "Should xasc sort both market_ticks and order_book"
 
     def test_returns_row_counts(self, mock_q):
         from kdbx.market_tables import load_parquet_data

--- a/ai-model-distillation-for-financial-data/tests/unit/tasks/test_generate_signals.py
+++ b/ai-model-distillation-for-financial-data/tests/unit/tasks/test_generate_signals.py
@@ -23,7 +23,7 @@ from bson import ObjectId
 
 from src.api.models import CustomizationResult, TaskResult
 from src.config import NIMConfig, settings
-from src.tasks.tasks import _parse_direction, generate_signals
+from src.tasks.tasks import _parse_direction, create_datasets, generate_signals
 
 
 def _as_task_result(result) -> TaskResult:
@@ -57,6 +57,24 @@ class TestParseDirection:
 
     def test_empty_string(self):
         assert _parse_direction("") == "HOLD"
+
+    def test_bullish_keyword(self):
+        assert _parse_direction("BULLISH outlook for tech") == "BUY"
+
+    def test_bearish_keyword(self):
+        assert _parse_direction("BEARISH sentiment in markets") == "SELL"
+
+    def test_beat_keyword(self):
+        assert _parse_direction("Earnings Beat") == "BUY"
+
+    def test_miss_keyword(self):
+        assert _parse_direction("Revenue Miss") == "SELL"
+
+    def test_upgrade_keyword(self):
+        assert _parse_direction("Analyst Upgrade to overweight") == "BUY"
+
+    def test_downgrade_keyword(self):
+        assert _parse_direction("Downgrade to sell") == "SELL"
 
     def test_buy_takes_precedence_over_sell(self):
         # BUY is checked first
@@ -235,3 +253,160 @@ class TestGenerateSignals:
 
         assert _as_task_result(result).error is None
         mock_write.assert_not_called()
+
+    @patch("kdbx.signals.write_signals_batch")
+    @patch("kdbx.enrichment.extract_sym_from_record")
+    @patch("src.tasks.tasks.RecordExporter")
+    @patch("src.tasks.tasks.requests.post")
+    def test_system_prompt_injected(
+        self, mock_post, mock_exporter_cls, mock_extract_sym, mock_write, base_result
+    ):
+        """Verify the NIM POST includes a system message from signal_config."""
+        records = [
+            {"request": {"messages": [{"role": "user", "content": "AAPL news"}]}},
+        ]
+        mock_exporter_cls.return_value.get_records.return_value = records
+        mock_extract_sym.return_value = "AAPL"
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": "BUY AAPL"}}]
+        }
+        mock_post.return_value = mock_resp
+
+        generate_signals(base_result, model_type="base")
+
+        sent_messages = mock_post.call_args[1]["json"]["messages"]
+        assert sent_messages[0]["role"] == "system"
+        assert sent_messages[0]["content"] == settings.signal_config.system_prompt
+        assert sent_messages[1]["role"] == "user"
+
+    @patch("kdbx.signals.write_signals_batch")
+    @patch("kdbx.enrichment.extract_sym_from_record")
+    @patch("src.tasks.tasks.RecordExporter")
+    @patch("src.tasks.tasks.requests.post")
+    def test_existing_system_message_not_duplicated(
+        self, mock_post, mock_exporter_cls, mock_extract_sym, mock_write, base_result
+    ):
+        """If record already has a system message, don't prepend another."""
+        records = [
+            {
+                "request": {
+                    "messages": [
+                        {"role": "system", "content": "Custom system prompt"},
+                        {"role": "user", "content": "AAPL news"},
+                    ]
+                }
+            },
+        ]
+        mock_exporter_cls.return_value.get_records.return_value = records
+        mock_extract_sym.return_value = "AAPL"
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": "SELL AAPL"}}]
+        }
+        mock_post.return_value = mock_resp
+
+        generate_signals(base_result, model_type="base")
+
+        sent_messages = mock_post.call_args[1]["json"]["messages"]
+        assert len(sent_messages) == 2
+        assert sent_messages[0]["role"] == "system"
+        assert sent_messages[0]["content"] == "Custom system prompt"
+
+
+# ---------------------------------------------------------------------------
+# Labeling integration tests (create_datasets path)
+# ---------------------------------------------------------------------------
+
+
+class TestLabelingInCreateDatasets:
+    """Test the market-return labeling block inside create_datasets."""
+
+    def _make_record(self, content: str = "", sym: str = "AAPL", ts: str = "2025-06-15T10:00:00"):
+        return {
+            "sym": sym,
+            "timestamp": ts,
+            "request": {"messages": [{"role": "user", "content": "News about AAPL"}]},
+            "response": {
+                "choices": [{"message": {"role": "assistant", "content": content}}]
+            },
+        }
+
+    @patch("src.tasks.tasks.DatasetCreator")
+    @patch("src.tasks.tasks.RecordExporter")
+    @patch("kdbx.labeling.pykx_connection")
+    def test_labeling_populates_empty_responses(
+        self, mock_pykx, mock_exporter_cls, mock_dataset_cls, monkeypatch
+    ):
+        """Records with empty content get labeled with market-return direction."""
+        import pandas as pd
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(settings.signal_config.labeling, "enabled", True, raising=False)
+        monkeypatch.setattr(settings.enrichment_config, "enabled", False, raising=False)
+
+        records = [self._make_record(content="")]
+        mock_exporter_cls.return_value.get_records.return_value = records
+
+        # Mock the pykx_connection to return BUY-worthy data
+        mock_conn = MagicMock()
+        result_mock = MagicMock()
+        result_mock.pd.return_value = pd.DataFrame([
+            {"entry_price": 100.0, "exit_price": 102.0},
+        ])
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.return_value = result_mock
+        mock_pykx.return_value = mock_conn
+
+        # Mock DatasetCreator to avoid downstream failures
+        mock_ds = MagicMock()
+        mock_ds.create_datasets.return_value = {}
+        mock_dataset_cls.return_value = mock_ds
+
+        # Build a minimal TaskResult
+        from bson import ObjectId
+        task_result = TaskResult(
+            workload_id="test",
+            flywheel_run_id=str(ObjectId()),
+            client_id="test-client",
+        )
+
+        create_datasets(task_result)
+
+        # The record's empty content should now be populated
+        content = records[0]["response"]["choices"][0]["message"]["content"]
+        assert content.startswith("BUY")
+        assert "AAPL" in content
+
+    @patch("src.tasks.tasks.DatasetCreator")
+    @patch("src.tasks.tasks.RecordExporter")
+    def test_labeling_skips_non_empty_responses(
+        self, mock_exporter_cls, mock_dataset_cls, monkeypatch
+    ):
+        """Records with existing content are not overwritten by labeling."""
+        monkeypatch.setattr(settings.signal_config.labeling, "enabled", True, raising=False)
+        monkeypatch.setattr(settings.enrichment_config, "enabled", False, raising=False)
+
+        existing_content = "SELL — analyst downgrade"
+        records = [self._make_record(content=existing_content)]
+        mock_exporter_cls.return_value.get_records.return_value = records
+
+        mock_ds = MagicMock()
+        mock_ds.create_datasets.return_value = {}
+        mock_dataset_cls.return_value = mock_ds
+
+        from bson import ObjectId
+        task_result = TaskResult(
+            workload_id="test",
+            flywheel_run_id=str(ObjectId()),
+            client_id="test-client",
+        )
+
+        create_datasets(task_result)
+
+        # Content should remain unchanged
+        content = records[0]["response"]["choices"][0]["message"]["content"]
+        assert content == existing_content


### PR DESCRIPTION
## Summary
- Hybrid training data labeling with market-return directions (BUY/SELL/HOLD)
- Fix `aj` lookups: `xasc` sort `market_ticks` by `sym,timestamp` for correct as-of joins
- Fix signal timestamps to use original event time instead of `datetime.utcnow()`
- Add system prompt to signal generation
- Sequential DAG with signal generation before each backtest

## Test plan
- [x] Unit tests pass (213 kdbx/signal tests green)
- [x] Deployed to EKS and verified backtest win_rate improved (base 13.2%, customized 41.2%)

