### PR TITLE
Sync data-flywheel from GitLab (2026-03-05)

### DIFF
--- a/ai-model-distillation-for-financial-data/docs/03-configuration.md
+++ b/ai-model-distillation-for-financial-data/docs/03-configuration.md
@@ -640,6 +640,31 @@ Enrichment adds 9 market context fields to each record: `market_close`, `market_
 
 > **📖 For details on enriched fields and the as-of join pipeline:** See [Workflow Orchestration — Market Data Enrichment](08-workflow-orchestration.md#how-market-data-enriches-student-model-training)
 
+## Signal Generation Configuration
+
+The `signal_config` section controls trading signal generation and training data labeling:
+
+```yaml
+signal_config:
+  system_prompt: >-
+    You are a financial trading signal generator.
+    Given a financial news headline or market event, respond with a clear
+    trading signal: BUY, SELL, or HOLD, followed by a brief rationale.
+  labeling:
+    enabled: true
+    return_threshold_bps: 50.0
+    horizon: "1D"
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `system_prompt` | System prompt prepended to NIM requests during signal generation | (see config.yaml) |
+| `labeling.enabled` | Enable market-return-based labeling for training records with empty responses | true |
+| `labeling.return_threshold_bps` | Threshold in basis points for BUY/SELL/HOLD classification. Returns above +threshold are BUY, below -threshold are SELL, otherwise HOLD | 50.0 |
+| `labeling.horizon` | Return lookforward period for label computation | "1D" |
+
+**Training data labeling**: When enabled, records with empty `response.choices[0].message.content` are automatically labeled using next-day market returns from `market_ticks` via KDB-X as-of joins. This produces objective ground-truth labels (BUY/SELL/HOLD) with template rationale strings (e.g., `"BUY — AAPL next-day return +1.50% ($185.50 → $188.28)"`). Labels are computed in-memory during `create_datasets` and flow directly into NeMo Customizer training data.
+
 ## Backtest Configuration
 
 The `backtest_config` section controls the financial backtesting evaluation:

--- a/ai-model-distillation-for-financial-data/docs/08-workflow-orchestration.md
+++ b/ai-model-distillation-for-financial-data/docs/08-workflow-orchestration.md
@@ -48,8 +48,8 @@ run_nim_workflow_dag.delay(
 )
 ```
 
-### 2. **`create_datasets`** (with enrichment)
-**Purpose**: Extracts data from KDB-X, creates training/evaluation datasets, and enriches training records with market-data features.
+### 2. **`create_datasets`** (with enrichment and labeling)
+**Purpose**: Extracts data from KDB-X, creates training/evaluation datasets, enriches training records with market-data features, and labels records with empty responses using market returns.
 
 **Source**: `src/tasks/tasks.py`
 
@@ -60,6 +60,7 @@ run_nim_workflow_dag.delay(
 - Applies data split configuration
 - Uploads datasets to NeMo Data Service
 - Runs market-data enrichment on training records (see below)
+- Runs market-return labeling on records with empty responses (see below)
 - Persists enrichment statistics (`records_enriched`, `features_added`, `enrichment_time_seconds`) to `flywheel_runs.enrichment_stats`
 
 **Dependencies**: `initialize_workflow`
@@ -145,6 +146,20 @@ flowchart LR
 
 **Configuration.** See [Enrichment Configuration](03-configuration.md#enrichment-configuration) for all options (`enabled`, `sym_field`, `sym_extraction`, `default_sym`).
 
+#### Market-Return Labeling for Training Data
+
+After enrichment, records with **empty** `response.choices[0].message.content` are labeled using next-day market returns from `market_ticks`. This is critical for fine-tuning: without labeled responses, the customized model learns to output nothing and produces 100% HOLD signals.
+
+**How it works:**
+1. For each record with an empty response, the pipeline extracts the ticker (`sym`) and event timestamp
+2. A KDB-X as-of join (`aj`) against `market_ticks` finds the close price at event time (entry) and 1 day later (exit)
+3. The next-day return determines the label: return > +threshold → BUY, < -threshold → SELL, else HOLD (threshold is configurable via `signal_config.labeling.return_threshold_bps`, default 50 bps = 0.5%)
+4. The response content is populated with a template rationale: `"BUY — AAPL next-day return +1.50% ($185.50 → $188.28)"`
+
+Records with existing (non-empty) response content are never overwritten.
+
+**Configuration.** See [Signal Generation Configuration](03-configuration.md#signal-generation-configuration) for all labeling options.
+
 #### ICL Example Selection Methods
 
 The developer example supports two methods for selecting in-context learning examples:
@@ -201,9 +216,11 @@ The developer example supports two methods for selecting in-context learning exa
 
 **Key Operations**:
 - Fetches evaluation records from KDB-X via `RecordExporter`
+- Prepends a configurable system prompt to each NIM request (from `signal_config.system_prompt`), unless the record already has a system message
 - Calls the NIM `/v1/chat/completions` endpoint for each record
 - Parses model responses to extract a trading direction (BUY/SELL/HOLD)
 - Extracts ticker symbols from records using `kdbx.enrichment.extract_sym_from_record`
+- Uses the original event timestamp from the record (not wall-clock time) for accurate backtesting
 - Writes signals in batch to the `signals` table via `kdbx.signals.write_signals_batch`
 
 **Dependencies**: `run_base_eval` (for base model) or `run_customization_eval` (for customized model)

--- a/ai-model-distillation-for-financial-data/docs/KDB-X-Architecture.md
+++ b/ai-model-distillation-for-financial-data/docs/KDB-X-Architecture.md
@@ -125,6 +125,14 @@ Enriches training records with point-in-time market context using KDB-X as-of jo
 - Features added: close, vwap, high, low, volume (from `market_ticks`) + bid_price, ask_price, spread, mid (from `order_book`)
 - Used during `create_datasets` to add market context to training pairs
 
+### `kdbx/labeling.py` — Market-Return Training Data Labeling
+
+Labels training records that have empty responses with objective BUY/SELL/HOLD directions computed from next-day market returns:
+- `compute_return_labels_batch(syms, timestamps, threshold_bps)` — batch `aj` query against `market_ticks` to get entry price at event time and exit price 1 day later; computes return percentage and classifies as BUY (> +threshold), SELL (< -threshold), or HOLD
+- `generate_template_rationale(direction, sym, return_pct, entry_price, exit_price)` — produces rationale strings like `"BUY — AAPL next-day return +1.50% ($185.50 → $188.28)"`
+- Used during `create_datasets` to populate empty `response.choices[0].message.content` fields before LoRA fine-tuning
+- Returns `direction=None` when market data is missing (record skipped gracefully)
+
 ### `kdbx/signals.py` — Batch Signal Writer
 
 Writes model trading signals to the KDB-X `signals` table using PyKX IPC:
@@ -144,7 +152,7 @@ Runs financial backtests using KDB-X as-of joins (`aj`):
 
 ### `kdbx/market_tables.py` — Market Table DDL
 
-Defines 4 financial market tables: `market_ticks`, `order_book`, `signals`, `backtest_results`. Includes a Parquet loader for bulk-inserting market data.
+Defines 4 financial market tables: `market_ticks`, `order_book`, `signals`, `backtest_results`. Includes a Parquet loader for bulk-inserting market data. After each data load, tables are sorted in-place with `` `sym`timestamp xasc `` to ensure correct `aj` (as-of join) behaviour.
 
 ### `kdbx/connection.py` — Connection Management
 
@@ -202,10 +210,11 @@ Data is persisted to a 50Gi EBS volume (`kdbai-storage` StorageClass, gp3).
 Phase 3 integrates financial analytics into the flywheel DAG:
 
 1. **Market-data enrichment** in `create_datasets` — uses `aj` (as-of join) to add point-in-time OHLCV + order book features (close, vwap, high, low, volume, bid, ask, spread, mid) to training records
-2. **Signal generation** — new Celery task (`generate_signals`) runs after each evaluation (base and customized), calling the deployed NIM with eval records and writing BUY/SELL/HOLD signals to the `signals` table via `kdbx/signals.py`
-3. **Backtest assessment** — `run_backtest_assessment` runs after each signal generation step, producing `backtest-eval` evaluations with Sharpe/drawdown/return metrics for both the base and customized models
-4. **Sequential DAG** — the pipeline runs fully sequentially: `base_eval → generate_signals(base) → backtest(base) → customization → cust_eval → generate_signals(customized) → backtest(customized)`
-5. **New API endpoints** — `POST /api/backtest` (ad-hoc) and `GET /api/market-status` (table stats)
-6. **`enrichment_stats`** — persisted on `flywheel_runs`, surfaced in job detail responses
+2. **Market-return labeling** in `create_datasets` — labels records with empty responses using next-day market returns from `market_ticks` via `kdbx/labeling.py`, producing BUY/SELL/HOLD labels with template rationale for fine-tuning
+3. **Signal generation** — Celery task (`generate_signals`) runs after each evaluation (base and customized), calling the deployed NIM with eval records and writing BUY/SELL/HOLD signals to the `signals` table via `kdbx/signals.py`; uses original event timestamps for accurate backtesting
+4. **Backtest assessment** — `run_backtest_assessment` runs after each signal generation step, producing `backtest-eval` evaluations with Sharpe/drawdown/return metrics for both the base and customized models
+5. **Sequential DAG** — the pipeline runs fully sequentially: `base_eval → generate_signals(base) → backtest(base) → customization → cust_eval → generate_signals(customized) → backtest(customized)`
+6. **New API endpoints** — `POST /api/backtest` (ad-hoc) and `GET /api/market-status` (table stats)
+7. **`enrichment_stats`** — persisted on `flywheel_runs`, surfaced in job detail responses
 
 The `flywheel_runs` table now includes an `enrichment_stats` column (general list, JSON-serialized) tracking records enriched, features added, and enrichment time.

--- a/ai-model-distillation-for-financial-data/docs/financial-backtesting.md
+++ b/ai-model-distillation-for-financial-data/docs/financial-backtesting.md
@@ -51,7 +51,9 @@ flowchart LR
 
 1. **Signal generation**: After each evaluation (base and customized), the `generate_signals` task calls the deployed NIM with the evaluation records and parses each response to extract a trading direction (BUY/SELL/HOLD). These signals are written to the KDB-X `signals` table with a timestamp, ticker symbol, model ID, and the model's rationale.
 
-2. **As-of join (`aj`)**: KDB-X's temporal join matches each signal to the most recent `close` price from `market_ticks` at the time the signal was generated, and again 1 day later for the exit price. This prevents look-ahead bias — the backtest only uses data that would have been available in real time.
+2. **As-of join (`aj`)**: KDB-X's temporal join matches each signal to the most recent `close` price from `market_ticks` at the time the signal was generated, and again 1 day later for the exit price. This prevents look-ahead bias — the backtest only uses data that would have been available in real time. Signals use the original event timestamp from the training record (not the time the signal was generated), ensuring accurate temporal alignment with market data.
+
+   > **Important**: The `market_ticks` table must be sorted by `sym` then `timestamp` for `aj` to return correct results. The data loaders (`market_tables.py`, `load_alpaca_data.py`) apply `` `sym`timestamp xasc `market_ticks `` after each data load to ensure correct sort order.
 
 3. **Trade simulation**: For each signal, the system enters a position at the entry price and exits at the close price 1 day later. Transaction costs are applied (default: 5 basis points round-trip).
 

--- a/ai-model-distillation-for-financial-data/docs/scripts.md
+++ b/ai-model-distillation-for-financial-data/docs/scripts.md
@@ -66,6 +66,38 @@ Example Helm values file for NeMo Microservices when deploying with minikube for
 - Pre-configures data-store, customizer targets (Llama 3.2 1B/3B, Llama 3.1 8B), evaluator, and ingress.
 - Used with `deploy-short.sh` or manual `helm install` commands.
 
+### `load_alpaca_data.py`
+
+Fetches real market data from Alpaca and loads it into KDB-X for POC and production use.
+
+- Downloads historical OHLCV bars from the Alpaca Data API
+- Derives order book data (bid/ask) from bar data with realistic spreads
+- Optionally fetches news headlines and formats them as training records for the `flywheel_logs` table
+- Supports Parquet-only mode (no KDB-X connection required)
+- Sorts `market_ticks` and `order_book` by `sym,timestamp` after loading for correct `aj` lookups
+
+**Environment variables:**
+- `ALPACA_API_KEY` — Alpaca API key ID (required)
+- `ALPACA_SECRET_KEY` — Alpaca API secret key (required)
+- `KDBX_ENDPOINT` — host:port of KDB-X (required unless `--parquet-only`)
+
+**Usage:**
+```bash
+# Save Parquet only (no KDB-X needed)
+ALPACA_API_KEY=xxx ALPACA_SECRET_KEY=yyy \
+    python scripts/load_alpaca_data.py --symbol AAPL --parquet-only
+
+# Save Parquet + load into KDB-X
+ALPACA_API_KEY=xxx ALPACA_SECRET_KEY=yyy KDBX_ENDPOINT=localhost:8082 \
+    python scripts/load_alpaca_data.py --symbol AAPL
+
+# Include news headlines (for flywheel_logs)
+ALPACA_API_KEY=xxx ALPACA_SECRET_KEY=yyy KDBX_ENDPOINT=localhost:8082 \
+    python scripts/load_alpaca_data.py --symbol AAPL --with-news
+```
+
+**Arguments:** `--symbol` (default: AAPL), `--days` (default: 365), `--timeframe` (default: 1Day), `--parquet-only`, `--with-news`, `--news-limit` (default: 200), `--out-dir` (default: data/alpaca).
+
 ### `generate_openapi.py`
 
 Python script to generate the OpenAPI specification for the API.


### PR DESCRIPTION
- Add labeling, signal timestamp, and xasc sort documentation
- Fix aj lookups: xasc sort market_ticks by sym,timestamp
- Fix signal timestamps to use original event time